### PR TITLE
Fixes NSCell inheritance (Xcode 7)

### DIFF
--- a/DMTabBar/DMTabBar/DMTabBarItem.h
+++ b/DMTabBar/DMTabBar/DMTabBarItem.h
@@ -11,13 +11,11 @@
 
 @interface DMTabBarItem : NSButtonCell
 
-@property (assign) BOOL enabled;                            
 @property (strong) NSImage *icon;
 @property (strong) NSImage *alternateIcon;
 @property (strong) NSString *toolTip;                       
 @property (copy) NSString *keyEquivalent;
 @property (assign) NSUInteger keyEquivalentModifierMask;    
-@property (assign) NSUInteger tag;                          
 @property (assign) NSInteger state;                         
 
 // Internal use

--- a/DMTabBar/DMTabBar/DMTabBarItem.m
+++ b/DMTabBar/DMTabBar/DMTabBarItem.m
@@ -71,12 +71,12 @@
     _tabBarItemButton.alternateImage = newIcon;
 }
 
-- (NSUInteger)tag
+- (NSInteger)tag
 {
     return _tabBarItemButton.tag;
 }
 
-- (void)setTag:(NSUInteger)newTag
+- (void)setTag:(NSInteger)newTag
 {
     _tabBarItemButton.tag = newTag;
 }


### PR DESCRIPTION
- `enabled` and `tag` aren't needed in `DMTabBarItem.h`, as they're already defined in the superclass.
- The tag implementation's return type now matches the superclass
